### PR TITLE
ubuntu1510: Do not make the udev rule file a directory

### DIFF
--- a/templates/ubuntu1510/scripts/cleanup.sh
+++ b/templates/ubuntu1510/scripts/cleanup.sh
@@ -9,7 +9,6 @@ rm /var/lib/dhcp/*
 
 echo "cleaning up udev rules"
 rm /etc/udev/rules.d/70-persistent-net.rules
-mkdir /etc/udev/rules.d/70-persistent-net.rules
 rm -rf /dev/.udev/
 rm /lib/udev/rules.d/75-persistent-net-generator.rules
 


### PR DESCRIPTION
This causes issues with installing new kernels

Since the generator is also removed we do not have to worry about
this file being created again
