### PR TITLE
ubuntu1604: Install a patched version of ifupdown package

### DIFF
--- a/templates/ubuntu1604/scripts/base.sh
+++ b/templates/ubuntu1604/scripts/base.sh
@@ -30,3 +30,32 @@ update-grub2
 echo "Prioritizing IPv6 resolvers"
 sed -i '2i 000.*' /etc/resolvconf/interface-order
 
+#
+# Ubuntu 16.04 ships with a broken ifupdown package which doesn't handle DHCPv6 properly
+#
+# https://bugs.launchpad.net/ubuntu/+source/ifupdown/+bug/1543352
+#
+# Ifupdown 0.8.11 contains this fix, but it also supports requesting a Prefix through
+# DHCPv6+PD (IA_PD)
+#
+# PCextreme Aurora Compute will support IPv6 Prefix Delegation in 2016 and this adds
+# support to the Ubuntu 16.04 template
+#
+# iface ens3 inet6 auto
+#   dhcp 1
+#   request_prefix 1
+#
+# See 'man interfaces' for more information
+#
+
+echo "Installing patched version of ifupdown for IPv6 PD support"
+wget -O /tmp/ifupdown.deb https://pcextreme.o.auroraobjects.eu/ubuntu/ifupdown_0.8.11_amd64.deb
+dpkg -i /tmp/ifupdown.deb
+
+echo "Adding IPv6 configuration to interfaces file"
+IFACE=$(cat /etc/network/interfaces|grep iface|tail -1|awk '{print $2}')
+
+echo "iface ${IFACE} inet6 auto" >> /etc/network/interfaces
+echo "# To enable IPv6 Prefix Delegation uncomment the lines below" >> /etc/network/interfaces
+echo "#    dhcp 1" >> /etc/network/interfaces
+echo "#    request_prefix 1" >> /etc/network/interfaces


### PR DESCRIPTION
Ubuntu 16.04 ships with a broken ifupdown package which doesn't handle DHCPv6 properly

https://bugs.launchpad.net/ubuntu/+source/ifupdown/+bug/1543352

Ifupdown 0.8.11 contains this fix, but it also supports requesting a Prefix through
DHCPv6+PD (IA_PD)

PCextreme Aurora Compute will support IPv6 Prefix Delegation in 2016 and this adds
support to the Ubuntu 16.04 template
