### PR TITLE
Install Qemu Guest Agent in all templates

### DIFF
--- a/templates/centos72/scripts/base.sh
+++ b/templates/centos72/scripts/base.sh
@@ -4,7 +4,7 @@ echo "Update packages"
 yum -y upgrade
 
 echo "Install packages"
-yum -y install at binutils curl dstat git iotop ipset lsof mc mtr nmap pciutils rsync screen strace tcpdump unzip net-tools uuid wget acpid policycoreutils iptraf-ng policycoreutils-python bind-utils redhat-lsb-core vim-enhanced
+yum -y install at binutils curl dstat git iotop ipset lsof mc mtr nmap pciutils rsync screen strace tcpdump unzip net-tools uuid wget acpid policycoreutils iptraf-ng policycoreutils-python bind-utils redhat-lsb-core vim-enhanced 	qemu-guest-agent
 
 unset HISTFILE
 

--- a/templates/debian83/scripts/base.sh
+++ b/templates/debian83/scripts/base.sh
@@ -5,7 +5,7 @@ apt-get update
 apt-get -y dist-upgrade
 
 echo "installing packages"
-apt-get -y install at binutils byobu curl dstat fping git htop iftop incron iotop ipset jq lsof mc mtr ncdu nmap pciutils rsync screen sl strace tcpdump unzip util-linux whois uuid wget acpid apparmor-utils apparmor-profiles apt-file dnsutils conntrack iptraf vim lsb-release xfsprogs apt-transport-https software-properties-common sysstat python-software-properties rdnssd
+apt-get -y install at binutils byobu curl dstat fping git htop iftop incron iotop ipset jq lsof mc mtr ncdu nmap pciutils rsync screen sl strace tcpdump unzip util-linux whois uuid wget acpid apparmor-utils apparmor-profiles apt-file dnsutils conntrack iptraf vim lsb-release xfsprogs apt-transport-https software-properties-common sysstat python-software-properties rdnssd qemu-guest-agent
 
 echo "installing cloud-set-guest-password"
 chmod +x /etc/network/if-up.d/cloud-set-guest-password

--- a/templates/ubuntu1404/scripts/base.sh
+++ b/templates/ubuntu1404/scripts/base.sh
@@ -5,7 +5,7 @@ apt-get update
 apt-get -y dist-upgrade
 
 echo "installing packages"
-apt-get -y install at binutils byobu curl dstat fping git htop iftop incron iotop ipset jq lsof mc mtr ncdu nmap pciutils rsync screen sl strace tcpdump unzip util-linux whois uuid wget acpid apparmor-utils apparmor-profiles apt-file dnsutils conntrack iptraf vim lsb-release xfsprogs apt-transport-https software-properties-common sysstat python-software-properties rdnssd
+apt-get -y install at binutils byobu curl dstat fping git htop iftop incron iotop ipset jq lsof mc mtr ncdu nmap pciutils rsync screen sl strace tcpdump unzip util-linux whois uuid wget acpid apparmor-utils apparmor-profiles apt-file dnsutils conntrack iptraf vim lsb-release xfsprogs apt-transport-https software-properties-common sysstat python-software-properties rdnssd qemu-guest-agent
 
 echo "install cloud-init"
 apt-get -y install cloud-init

--- a/templates/ubuntu1604/scripts/base.sh
+++ b/templates/ubuntu1604/scripts/base.sh
@@ -5,7 +5,7 @@ apt-get update
 apt-get -y dist-upgrade
 
 echo "installing packages"
-apt-get -y install at binutils byobu curl dstat fping git htop iftop incron iotop ipset jq lsof mc mtr ncdu nmap pciutils rsync screen sl strace tcpdump unzip util-linux whois uuid wget acpid apparmor-utils apparmor-profiles apt-file dnsutils conntrack iptraf vim lsb-release xfsprogs apt-transport-https software-properties-common sysstat python-software-properties rdnssd
+apt-get -y install at binutils byobu curl dstat fping git htop iftop incron iotop ipset jq lsof mc mtr ncdu nmap pciutils rsync screen sl strace tcpdump unzip util-linux whois uuid wget acpid apparmor-utils apparmor-profiles apt-file dnsutils conntrack iptraf vim lsb-release xfsprogs apt-transport-https software-properties-common sysstat python-software-properties rdnssd qemu-guest-agent
 
 echo "install cloud-init"
 apt-get -y install cloud-init


### PR DESCRIPTION
Although CloudStack does not provide the port yet this feature
is being worked on.

By adding the Agent to the templates already we make sure that
when we add the port communication with the guests becomes available.
