### PR TITLE
Install Watchdog daemon for automated reboots on system hang

### DIFF
--- a/templates/centos72/files/watchdog.conf
+++ b/templates/centos72/files/watchdog.conf
@@ -1,0 +1,50 @@
+#
+# Watchdog configuration for inside KVM/Qemu Virtual Machine with Intel i6300ESB
+#
+# More information: https://libvirt.org/formatdomain.html#elementsWatchdog
+#
+# Make sure the i6300esb kernel module is loaded
+#
+# $ modprobe i6300esb
+#
+#ping			= 172.31.14.1
+#ping			= 172.26.1.255
+#interface		= eth0
+#file			= /var/log/messages
+#change			= 1407
+
+# Uncomment to enable test. Setting one of these values to '0' disables it.
+# These values will hopefully never reboot your machine during normal use
+# (if your machine is really hung, the loadavg will go much higher than 25)
+#max-load-1		= 24
+#max-load-5		= 18
+#max-load-15		= 12
+
+# Note that this is the number of pages!
+# To get the real size, check how large the pagesize is on your machine.
+#min-memory		= 1
+
+#repair-binary		= /usr/sbin/repair
+#repair-timeout		= 
+#test-binary		= 
+#test-timeout		= 
+
+watchdog-device		= /dev/watchdog
+
+# Defaults compiled into the binary
+#temperature-device	=
+#max-temperature	= 120
+
+# Defaults compiled into the binary
+#admin			= root
+interval		= 5
+logtick			= 1
+log-dir			= /var/log/watchdog
+
+# This greatly decreases the chance that watchdog won't be scheduled before
+# your machine is really loaded
+realtime		= yes
+priority		= 1
+
+# Check if rsyslogd is still running by enabling the following line
+#pidfile		= /var/run/rsyslogd.pid

--- a/templates/centos72/scripts/base.sh
+++ b/templates/centos72/scripts/base.sh
@@ -4,7 +4,7 @@ echo "Update packages"
 yum -y upgrade
 
 echo "Install packages"
-yum -y install at binutils curl dstat git iotop ipset lsof mc mtr nmap pciutils rsync screen strace tcpdump unzip net-tools uuid wget acpid policycoreutils iptraf-ng policycoreutils-python bind-utils redhat-lsb-core vim-enhanced 	qemu-guest-agent
+yum -y install at binutils curl dstat git iotop ipset lsof mc mtr nmap pciutils rsync screen strace tcpdump unzip net-tools uuid wget acpid policycoreutils iptraf-ng policycoreutils-python bind-utils redhat-lsb-core vim-enhanced qemu-guest-agent watchdog
 
 unset HISTFILE
 
@@ -28,3 +28,6 @@ grub2-mkconfig > /boot/grub2/grub.cfg
 
 echo "Do not use IPv4 DHCP DNS"
 sed -i 's|^PEERDNS=yes|PEERDNS=no|g' /etc/sysconfig/network-scripts/ifcfg-eth0
+
+echo "Making sure i6300esb Watchdog is loaded"
+echo i6300esb >> /etc/modules

--- a/templates/centos72/template.json
+++ b/templates/centos72/template.json
@@ -85,6 +85,11 @@
                 "../../scripts/zerodisk.sh"
             ],
             "execute_command": "sh '{{.Path}}'"
+        },
+        {
+            "type": "file",
+            "source": "files/watchdog.conf",
+            "destination": "/etc/watchdog.conf"
         }
     ]
 }

--- a/templates/debian83/files/watchdog.conf
+++ b/templates/debian83/files/watchdog.conf
@@ -1,0 +1,50 @@
+#
+# Watchdog configuration for inside KVM/Qemu Virtual Machine with Intel i6300ESB
+#
+# More information: https://libvirt.org/formatdomain.html#elementsWatchdog
+#
+# Make sure the i6300esb kernel module is loaded
+#
+# $ modprobe i6300esb
+#
+#ping			= 172.31.14.1
+#ping			= 172.26.1.255
+#interface		= eth0
+#file			= /var/log/messages
+#change			= 1407
+
+# Uncomment to enable test. Setting one of these values to '0' disables it.
+# These values will hopefully never reboot your machine during normal use
+# (if your machine is really hung, the loadavg will go much higher than 25)
+#max-load-1		= 24
+#max-load-5		= 18
+#max-load-15		= 12
+
+# Note that this is the number of pages!
+# To get the real size, check how large the pagesize is on your machine.
+#min-memory		= 1
+
+#repair-binary		= /usr/sbin/repair
+#repair-timeout		= 
+#test-binary		= 
+#test-timeout		= 
+
+watchdog-device		= /dev/watchdog
+
+# Defaults compiled into the binary
+#temperature-device	=
+#max-temperature	= 120
+
+# Defaults compiled into the binary
+#admin			= root
+interval		= 5
+logtick			= 1
+log-dir			= /var/log/watchdog
+
+# This greatly decreases the chance that watchdog won't be scheduled before
+# your machine is really loaded
+realtime		= yes
+priority		= 1
+
+# Check if rsyslogd is still running by enabling the following line
+#pidfile		= /var/run/rsyslogd.pid

--- a/templates/debian84/scripts/base.sh
+++ b/templates/debian84/scripts/base.sh
@@ -24,3 +24,5 @@ update-grub2
 echo "Prioritizing IPv6 Resolvers"
 sed -i '2i 000.*' /etc/resolvconf/interface-order
 
+echo "Making sure i6300esb Watchdog is loaded"
+echo i6300esb >> /etc/modules

--- a/templates/debian84/template.json
+++ b/templates/debian84/template.json
@@ -100,6 +100,11 @@
                 "../../scripts/zerodisk.sh"
             ],
             "execute_command": "sh '{{.Path}}'"
+        },
+        {
+            "type": "file",
+            "source": "files/watchdog.conf",
+            "destination": "/etc/watchdog.conf"
         }
     ]
 }

--- a/templates/ubuntu1404/files/watchdog.conf
+++ b/templates/ubuntu1404/files/watchdog.conf
@@ -1,0 +1,50 @@
+#
+# Watchdog configuration for inside KVM/Qemu Virtual Machine with Intel i6300ESB
+#
+# More information: https://libvirt.org/formatdomain.html#elementsWatchdog
+#
+# Make sure the i6300esb kernel module is loaded
+#
+# $ modprobe i6300esb
+#
+#ping			= 172.31.14.1
+#ping			= 172.26.1.255
+#interface		= eth0
+#file			= /var/log/messages
+#change			= 1407
+
+# Uncomment to enable test. Setting one of these values to '0' disables it.
+# These values will hopefully never reboot your machine during normal use
+# (if your machine is really hung, the loadavg will go much higher than 25)
+#max-load-1		= 24
+#max-load-5		= 18
+#max-load-15		= 12
+
+# Note that this is the number of pages!
+# To get the real size, check how large the pagesize is on your machine.
+#min-memory		= 1
+
+#repair-binary		= /usr/sbin/repair
+#repair-timeout		= 
+#test-binary		= 
+#test-timeout		= 
+
+watchdog-device		= /dev/watchdog
+
+# Defaults compiled into the binary
+#temperature-device	=
+#max-temperature	= 120
+
+# Defaults compiled into the binary
+#admin			= root
+interval		= 5
+logtick			= 1
+log-dir			= /var/log/watchdog
+
+# This greatly decreases the chance that watchdog won't be scheduled before
+# your machine is really loaded
+realtime		= yes
+priority		= 1
+
+# Check if rsyslogd is still running by enabling the following line
+#pidfile		= /var/run/rsyslogd.pid

--- a/templates/ubuntu1404/scripts/base.sh
+++ b/templates/ubuntu1404/scripts/base.sh
@@ -5,7 +5,7 @@ apt-get update
 apt-get -y dist-upgrade
 
 echo "installing packages"
-apt-get -y install at binutils byobu curl dstat fping git htop iftop incron iotop ipset jq lsof mc mtr ncdu nmap pciutils rsync screen sl strace tcpdump unzip util-linux whois uuid wget acpid apparmor-utils apparmor-profiles apt-file dnsutils conntrack iptraf vim lsb-release xfsprogs apt-transport-https software-properties-common sysstat python-software-properties rdnssd qemu-guest-agent
+apt-get -y install at binutils byobu curl dstat fping git htop iftop incron iotop ipset jq lsof mc mtr ncdu nmap pciutils rsync screen sl strace tcpdump unzip util-linux whois uuid wget acpid apparmor-utils apparmor-profiles apt-file dnsutils conntrack iptraf vim lsb-release xfsprogs apt-transport-https software-properties-common sysstat python-software-properties rdnssd qemu-guest-agent watchdog
 
 echo "install cloud-init"
 apt-get -y install cloud-init
@@ -29,3 +29,6 @@ update-grub2
 
 echo "Prioritizing IPv6 resolvers"
 sed -i '2i 000.*' /etc/resolvconf/interface-order
+
+echo "Making sure i6300esb Watchdog is loaded"
+echo i6300esb >> /etc/modules

--- a/templates/ubuntu1404/template.json
+++ b/templates/ubuntu1404/template.json
@@ -91,6 +91,11 @@
                 "../../scripts/zerodisk.sh"
             ],
             "execute_command": "sh '{{.Path}}'"
+        },
+        {
+            "type": "file",
+            "source": "files/watchdog.conf",
+            "destination": "/etc/watchdog.conf"
         }
     ]
 }

--- a/templates/ubuntu1604/files/watchdog.conf
+++ b/templates/ubuntu1604/files/watchdog.conf
@@ -1,0 +1,50 @@
+#
+# Watchdog configuration for inside KVM/Qemu Virtual Machine with Intel i6300ESB
+#
+# More information: https://libvirt.org/formatdomain.html#elementsWatchdog
+#
+# Make sure the i6300esb kernel module is loaded
+#
+# $ modprobe i6300esb
+#
+#ping			= 172.31.14.1
+#ping			= 172.26.1.255
+#interface		= eth0
+#file			= /var/log/messages
+#change			= 1407
+
+# Uncomment to enable test. Setting one of these values to '0' disables it.
+# These values will hopefully never reboot your machine during normal use
+# (if your machine is really hung, the loadavg will go much higher than 25)
+#max-load-1		= 24
+#max-load-5		= 18
+#max-load-15		= 12
+
+# Note that this is the number of pages!
+# To get the real size, check how large the pagesize is on your machine.
+#min-memory		= 1
+
+#repair-binary		= /usr/sbin/repair
+#repair-timeout		= 
+#test-binary		= 
+#test-timeout		= 
+
+watchdog-device		= /dev/watchdog
+
+# Defaults compiled into the binary
+#temperature-device	=
+#max-temperature	= 120
+
+# Defaults compiled into the binary
+#admin			= root
+interval		= 5
+logtick			= 1
+log-dir			= /var/log/watchdog
+
+# This greatly decreases the chance that watchdog won't be scheduled before
+# your machine is really loaded
+realtime		= yes
+priority		= 1
+
+# Check if rsyslogd is still running by enabling the following line
+#pidfile		= /var/run/rsyslogd.pid

--- a/templates/ubuntu1604/scripts/base.sh
+++ b/templates/ubuntu1604/scripts/base.sh
@@ -5,7 +5,7 @@ apt-get update
 apt-get -y dist-upgrade
 
 echo "installing packages"
-apt-get -y install at binutils byobu curl dstat fping git htop iftop incron iotop ipset jq lsof mc mtr ncdu nmap pciutils rsync screen sl strace tcpdump unzip util-linux whois uuid wget acpid apparmor-utils apparmor-profiles apt-file dnsutils conntrack iptraf vim lsb-release xfsprogs apt-transport-https software-properties-common sysstat python-software-properties rdnssd qemu-guest-agent
+apt-get -y install at binutils byobu curl dstat fping git htop iftop incron iotop ipset jq lsof mc mtr ncdu nmap pciutils rsync screen sl strace tcpdump unzip util-linux whois uuid wget acpid apparmor-utils apparmor-profiles apt-file dnsutils conntrack iptraf vim lsb-release xfsprogs apt-transport-https software-properties-common sysstat python-software-properties rdnssd qemu-guest-agent watchdog
 
 echo "install cloud-init"
 apt-get -y install cloud-init
@@ -59,3 +59,6 @@ echo "iface ${IFACE} inet6 auto" >> /etc/network/interfaces
 echo "# To enable IPv6 Prefix Delegation uncomment the lines below" >> /etc/network/interfaces
 echo "#    dhcp 1" >> /etc/network/interfaces
 echo "#    request_prefix 1" >> /etc/network/interfaces
+
+echo "Making sure i6300esb Watchdog is loaded"
+echo i6300esb >> /etc/modules

--- a/templates/ubuntu1604/template.json
+++ b/templates/ubuntu1604/template.json
@@ -104,6 +104,11 @@
                 "../../scripts/zerodisk.sh"
             ],
             "execute_command": "sh '{{.Path}}'"
+        },
+        {
+            "type": "file",
+            "source": "files/watchdog.conf",
+            "destination": "/etc/watchdog.conf"
         }
     ]
 }


### PR DESCRIPTION
By presenting the Intel i6300ESB Watchdog timer through Qemu/Libvirt
we can reboot Instances automatically should they hang.

This requires the Watchdog daemon to run inside the VM and send
heartbeats to the watchdog device. Otherwise the Hypervisor will not
be able to identify if the VM has crashed.

More information: https://libvirt.org/formatdomain.html#elementsWatchdog
