### PR TITLE
Cloudlinux 8

### DIFF
--- a/files/generic/cloud-init.cfg
+++ b/files/generic/cloud-init.cfg
@@ -23,16 +23,17 @@ cloud_init_modules:
  - resizefs
  - disk_setup
  - set_hostname
- - [ set-passwords, always ]
+ - users_groups
+ - [ set_passwords, always ]
  - update_hostname
  - update_etc_hosts
  - ssh
- - ssh-import-id
+ - ssh_import_id
  - timezone
  - runcmd
 
 cloud_final_modules:
-  - scripts-user
+  - scripts_user
 
 warnings:
   dsid_missing_source: off

--- a/files/kickstart/cloudlinux-8.ks
+++ b/files/kickstart/cloudlinux-8.ks
@@ -43,41 +43,15 @@ selinux --enforcing
 
 # Package installation
 %packages --ignoremissing
-@^server-product-environment
-@guest-agents
-acpid
-at
-bind-utils
-binutils
+@^minimal-environment
+open-vm-tools
 cloud-init
 cloud-utils-growpart
-curl
-deltarpm
-dracut-config-generic
-dstat
-git
-iotop
-ipset
-iptraf-ng
-kexec-tools
-lsof
-mc
-mtr
-nano
-net-tools
-nmap
-pciutils
-policycoreutils
-policycoreutils-python
-redhat-lsb-core
-rsync
-screen
-strace
-tcpdump
-unzip
-uuid
-vim-enhanced
-wget
+iptables
+-alsa-*
+-firewalld
+-ivtv*
+-iwl*firmware
 %end
 
 %anaconda

--- a/scripts/cloudlinux-8/post.sh
+++ b/scripts/cloudlinux-8/post.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 
 echo "Remove DHCP leases"
 find /var/lib -type f -name '*.lease' -print -delete


### PR DESCRIPTION
a few fixes in the cloudlinux-8 template

remove set -x used for debugging purposes
add a module (users_groups) to cloud.cfg and change module-names to underscores
also a more minimal kickstart file