### PR TITLE
fix: disable CL8 selinux and correct guest agent

### DIFF
--- a/files/kickstart/cloudlinux-8.ks
+++ b/files/kickstart/cloudlinux-8.ks
@@ -39,12 +39,12 @@ timezone Europe/Amsterdam --isUtc
 part / --fstype xfs --fsoptions="rw,noatime" --size=1 --grow
 
 # Enable SELinux
-selinux --enforcing
+selinux --disabled
 
 # Package installation
 %packages --ignoremissing
 @^minimal-environment
-open-vm-tools
+qemu-guest-agent
 cloud-init
 cloud-utils-growpart
 iptables


### PR DESCRIPTION
fix: cloudlinux requires selinux to be disabled and qemu-guest-agent instead of open-vm-tools